### PR TITLE
Changed artifactName and fixed platform suffix handling

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 
 Mill plugin to export dependency information to be processed by Scala-Steward.
 
-See https://github.com/scala-steward-org/scala-steward/issues/2704, for details.
+See https://github.com/scala-steward-org/scala-steward/issues/2704 and https://github.com/scala-steward-org/scala-steward/issues/2818 for details.
 
 == Usage
 

--- a/build.sc
+++ b/build.sc
@@ -71,8 +71,8 @@ class PluginCross(millPlatform: String)
 
   override def millSourcePath: os.Path = super.millSourcePath / os.up
   override def scalaVersion: T[String] = config.scalaVersion
-  override def artifactName: T[String] = "mill-scala-steward"
-  override def platformSuffix: T[String] = "_mill0.10"
+  override def artifactName: T[String] = "scala-steward-mill-plugin"
+  override def platformSuffix: T[String] = s"_mill${millPlatform}"
   override def artifactId: T[String] =
     artifactName() + platformSuffix() + artifactSuffix()
   override def scalacOptions = Seq("-Ywarn-unused", "-deprecation")


### PR DESCRIPTION
We now use the artifactName `scala-steward-mill-plugin` which was already used for previous versions.
