### PR TITLE
Fix artifactId of published modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,13 @@ jobs:
         run:
           ./mill --no-server __.compile
 
+      - name: Package
+        run: ./mill --no-server show __.publishArtifacts
+
       - name: Test
         run:
           # The -j1 is to workaround concurrency issues in older Mill version (0.8.0) when itest-ing
           ./mill --no-server -j1 --debug __.test
-
-      - name: Package
-        run: ./mill --no-server show __.publishArtifacts
 
   publish-sonatype:
     if: github.repository == 'scala-steward-org/mill-plugin' && contains(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,15 @@ jobs:
 
       - name: Compile
         run:
-          ./mill -i __.compile
+          ./mill --no-server __.compile
 
       - name: Test
         run:
           # The -j1 is to workaround concurrency issues in older Mill version (0.8.0) when itest-ing
           ./mill --no-server -j1 --debug __.test
+
+      - name: Package
+        run: ./mill --no-server show __.publishArtifacts
 
   publish-sonatype:
     if: github.repository == 'scala-steward-org/mill-plugin' && contains(github.ref, 'refs/tags/')

--- a/build.sc
+++ b/build.sc
@@ -74,8 +74,6 @@ trait PluginCross
   override def scalaVersion: T[String] = config.scalaVersion
   override def artifactName: T[String] = "scala-steward-mill-plugin"
   override def platformSuffix: T[String] = s"_mill${millPlatform}"
-  override def artifactId: T[String] =
-    artifactName() + platformSuffix() + artifactSuffix()
   override def scalacOptions = Seq(
     "-release",
     "8",


### PR DESCRIPTION
Version 0.18.1 was released with invalid artifactId of the form:
`scala-steward-mill-plugin_mill0.11_mill0.11_2.13`


Instead it should containt the platform suffix only once:
`scala-steward-mill-plugin_mill0.11_2.13`


Mill 0.12 slightly changed how platform suffixes get rendered, so we need to adapt the build config.

Fix https://github.com/scala-steward-org/mill-plugin/issues/94