### PR TITLE
Fix malformed JSON headers encoding

### DIFF
--- a/plugin/src-mill0/org/scalasteward/mill/plugin/StewardPluginBase.scala
+++ b/plugin/src-mill0/org/scalasteward/mill/plugin/StewardPluginBase.scala
@@ -140,7 +140,7 @@ trait StewardPluginBase extends Module {
                 .getOrElse(Null),
             "headers" ->
               m.authentication
-                .map(headers => Arr(headers.httpHeaders.map(headerJson)))
+                .map(headers => Arr.from(headers.httpHeaders.map(headerJson)))
                 .getOrElse(Null)
           )
         case ivy: IvyRepository =>
@@ -153,7 +153,7 @@ trait StewardPluginBase extends Module {
                 .getOrElse(Null),
             "headers" ->
               ivy.authentication
-                .map(headers => Arr(headers.httpHeaders.map(headerJson)))
+                .map(headers => Arr.from(headers.httpHeaders.map(headerJson)))
                 .getOrElse(Null)
           )
         case _ => Null

--- a/plugin/src-mill1/org/scalasteward/mill/plugin/StewardPlugin.scala
+++ b/plugin/src-mill1/org/scalasteward/mill/plugin/StewardPlugin.scala
@@ -132,7 +132,7 @@ object StewardPlugin extends ExternalModule {
                 .getOrElse(Null),
             "headers" ->
               m.authentication
-                .map(headers => Arr(headers.httpHeaders.map(headerJson)))
+                .map(headers => Arr.from(headers.httpHeaders.map(headerJson)))
                 .getOrElse(Null)
           )
         case ivy: IvyRepository =>
@@ -145,7 +145,7 @@ object StewardPlugin extends ExternalModule {
                 .getOrElse(Null),
             "headers" ->
               ivy.authentication
-                .map(headers => Arr(headers.httpHeaders.map(headerJson)))
+                .map(headers => Arr.from(headers.httpHeaders.map(headerJson)))
                 .getOrElse(Null)
           )
         case _ => Null


### PR DESCRIPTION
* Fix https://github.com/scala-steward-org/mill-plugin/issues/136

Replace use of `Arr.apply` with `Arr.from` to avoid creating a nested JSON array.